### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/clemency-as/assembler.py
+++ b/clemency-as/assembler.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import subprocess
 import parser
 import instrs
@@ -18,12 +19,12 @@ def main(argv):
     if args.outfile is None:
         args.outfile = os.path.splitext(args.infile)[0] + '.bin'
 
-    print "Assembling %s to %s..." % (args.infile, args.outfile)
+    print("Assembling %s to %s..." % (args.infile, args.outfile))
 
     asm = subprocess.check_output(['cpp', '-xc++', args.infile])
 
     out = parser.Assembler().assemble(asm)
-    print "Output: %d nytes" % (len(out)/9)
+    print("Output: %d nytes" % (len(out)/9))
     with open(args.outfile, 'wb') as outf:
         outf.write(out.force_str())
 

--- a/clemency-as/instrs.py
+++ b/clemency-as/instrs.py
@@ -9,7 +9,7 @@ orderedconds = "sge sg sle sl ns no ge le n e l g o s".split()
 specials     = [".", "I", "D"] + orderedconds
 
 def u(x, ip=None):
-  if type(x) is pyparsing.ParseResults:
+  if isinstance(x, pyparsing.ParseResults):
     return x.asList()[0]
   if isinstance(x, Symbolic):
     return x.value(ip)

--- a/clemency-exploit-utils/clemency/struct.py
+++ b/clemency-exploit-utils/clemency/struct.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 import StringIO
 from string import printable
@@ -39,7 +40,7 @@ class ClemencyFile(object):
 
   def _readflush(self):
     if self.rp != 0:
-      print >> sys.stderr, "WARNING: _readflush flushed %d nonzero bits - your read lengths are wrong" % self.rpn
+      print("WARNING: _readflush flushed %d nonzero bits - your read lengths are wrong" % self.rpn, file=sys.stderr)
     self.rpn = 0
     self.rp = 0
 
@@ -68,7 +69,7 @@ class ClemencyFile(object):
         out.append(self._readnyte())
       self._readflush()
     except BaseException as e:
-      print "Read interrupted (%s); partial output:" % e, out
+      print("Read interrupted (%s); partial output:" % e, out)
       raise
     return ClemencyBuffer(out)
 
@@ -85,7 +86,7 @@ class ClemencyFile(object):
 
     out = []
     try:
-      while 1:
+      while True:
         n = self._readnyte()
         out.append(n)
         if len(out) == maxsize:
@@ -97,7 +98,7 @@ class ClemencyFile(object):
           continue
         break
     except BaseException as e:
-      print "Read interrupted (%s); partial output:" % e, out
+      print("Read interrupted (%s); partial output:" % e, out)
       raise
     self._readflush()
     return ClemencyBuffer(out)
@@ -114,7 +115,7 @@ class ClemencyFile(object):
     while True:
       try:
         output.append(self._readnyte())
-      except DoneReadingException, e:
+      except DoneReadingException as e:
         break
     return ClemencyBuffer(output)
 
@@ -142,15 +143,15 @@ class ClemencyBuffer(object):
   def add(self, b):
     self.push(b)
   def __getitem__(self, key):
-    if type(key) == int:
+    if isinstance(key, int):
       return self._buf[key]
-    elif type(key) == slice:
+    elif isinstance(key, slice):
       sl = self._buf[key.start:key.stop:key.step]
       return ClemencyBuffer(sl)
   def __setitem__(self, key, value):
-    if type(value) == int:
+    if isinstance(value, int):
       self._buf[key] = value
-    elif type(value) == str:
+    elif isinstance(value, str):
       assert len(value) <= 2
       if len(value) == 1:
         self._buf[key] = ord(value)
@@ -160,17 +161,17 @@ class ClemencyBuffer(object):
     else:
       assert False
   def __add__(self, other):
-    if type(other) == list:
+    if isinstance(other, list):
       return ClemencyBuffer(self._buf + other)
-    elif type(other) == str:
+    elif isinstance(other, str):
       assert all(c in printable for c in other)
       return self + ClemencyBuffer.from_string(other)
-    elif type(other) == type(self):
+    elif isinstance(other, type(self)):
       return ClemencyBuffer(self._buf + other._buf)
     else:
       assert False
   def __mul__(self, other):
-    assert type(other) == int
+    assert isinstance(other, int)
     return ClemencyBuffer(self._buf * other)
   def __repr__(self):
     return "ClemencyBuffer(%r)" % self._buf
@@ -209,7 +210,7 @@ class ClemencyBuffer(object):
   def __iter__(self):
     return self._buf.__iter__()
   def __eq__(self, other):
-    if type(other) != type(self):
+    if not isinstance(other, type(self)):
       return False
     return other._buf == self._buf
   def __ne__(self, other):
@@ -221,13 +222,13 @@ class ClemencyBuffer(object):
     assert 0 <= filler <= 0x1ff
     return ClemencyBuffer(([filler] * (nBytes - len(self))) + self._buf)
   def index(self, buf):
-    if type(buf) == int:
+    if isinstance(buf, int):
       return self._buf.index(buf)
-    if type(buf) == list:
+    if isinstance(buf, list):
       buf = ClemencyBuffer(buf)
-    elif type(buf) == str:
+    elif isinstance(buf, str):
       buf = ClemencyBuffer.from_string(buf)
-    elif type(buf) != type(self):
+    elif not isinstance(buf, type(self)):
       assert False
     # lol stolen from stackoverflow
     def getsubidx(x, y):
@@ -399,7 +400,7 @@ def unpack(fmt, s):
     (12107830635004600, -48232576)
   '''
   total_length = calcsize(fmt)
-  if type(s) == str:
+  if isinstance(s, str):
     io = StringIO.StringIO(s)
     io.seek(0)
     data = ClemencyFile(io).read_all()

--- a/snowball/clemency/ida-plugin/clemency-dump.py
+++ b/snowball/clemency/ida-plugin/clemency-dump.py
@@ -1,6 +1,7 @@
 """
 Dumps to original_binary.bin.patched.
 """
+from __future__ import print_function
 
 import struct
 import os
@@ -51,11 +52,11 @@ def write_patch():
     input_file_path = idaapi.get_input_file_path()
 
     if not os.path.exists(input_file_path):
-        print "ClemDump: warning: {} does not exist.".format(input_file_path)
+        print("ClemDump: warning: {} does not exist.".format(input_file_path))
 
     output_path = input_file_path + '.patched'
 
-    print "ClemDump: patched binary to", output_path
+    print("ClemDump: patched binary to", output_path)
     with open(output_path, 'wb') as output_fd:
         ClemencyFile(output_fd).write(get_first_segment())
 

--- a/snowball/clemency/ida-plugin/clemency-symbols.py
+++ b/snowball/clemency/ida-plugin/clemency-symbols.py
@@ -1,6 +1,7 @@
 """
 Saves all function names in idb to symbol map for org's Clemency debugger.
 """
+from __future__ import print_function
 
 import os
 import idaapi
@@ -19,7 +20,7 @@ def get_symbol_map():
     output_lines = []
     for i, (ea, (name, size)) in enumerate(sorted(functions.items())):
         if len(name) > 255:
-            print "ClemSym: truncating name", name
+            print("ClemSym: truncating name", name)
         name = name[:255]
         line = "%d: %s @ %07x %d" % (i, name, ea, size)
         output_lines.append(line)
@@ -32,7 +33,7 @@ def save_symbols():
     input_file_path = idaapi.get_input_file_path()
 
     if not os.path.exists(input_file_path):
-        print "ClemSym: warning: {} does not exist.".format(input_file_path)
+        print("ClemSym: warning: {} does not exist.".format(input_file_path))
 
     output_path = input_file_path + '.map'
 
@@ -42,7 +43,7 @@ def save_symbols():
         with open(output_path, 'rb') as orig_fd:
             orig_data = orig_fd.read()
         if orig_data == new_data:
-            print "ClemSym: symbol map on disk is already up to date"
+            print("ClemSym: symbol map on disk is already up to date")
             return
 
         # Always backup as we *really* don't want to kill someone's
@@ -52,7 +53,7 @@ def save_symbols():
             bak_ctr += 1
         os.rename(output_path, output_path + '.bak' + str(bak_ctr))
 
-    print "ClemSym: writing symbols to", output_path
+    print("ClemSym: writing symbols to", output_path)
     with open(output_path, 'wb') as output_fd:
         output_fd.write(new_data)
 

--- a/snowball/clemency/test.py
+++ b/snowball/clemency/test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 import ctypes
 import pyclemency
 import struct
@@ -15,7 +16,7 @@ while True:
     for x in xrange(size):
         code[x] = struct.unpack('<H', buf[(pc+x)*2:(pc+x+1)*2])[0]
     inst = pyclemency.disassemble(pc, code)
-    print '%08X\t%s' % (pc, inst.str)
+    print('%08X\t%s' % (pc, inst.str))
     if inst.id == 0:
         break
     pc += inst.size

--- a/snowball/riscv/test.py
+++ b/snowball/riscv/test.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
+from __future__ import print_function
 import pyriscv
 
 code = open('test.bin', 'rb').read()
 for pc in xrange(0, len(code), 4):
     inst = pyriscv.disassemble(pc, code[pc:pc+4])
-    print '%08X\t%s' % (pc, inst.str)
+    print('%08X\t%s' % (pc, inst.str))


### PR DESCRIPTION
* Use __print()__ function in both Python 2 and Python 3
    * __print()__ is a function in Python 3.
* Old style exceptions --> new style in Python 3
    * Python 3 treats old style exceptions as syntax errors but new style exceptions work as expected in both Python 2 and Python 3.